### PR TITLE
Fixed issues with CancelTransaction and CheckTransaction

### DIFF
--- a/Paycom/Application.php
+++ b/Paycom/Application.php
@@ -284,7 +284,7 @@ class Application
 
                 // change order state to cancelled
                 $order = new Order($this->request->id);
-                $order->find($this->request->params);
+                $order->find(['order_id' => $found->order_id]);
                 $order->changeState(Order::STATE_CANCELLED);
 
                 // send response
@@ -298,7 +298,7 @@ class Application
             case Transaction::STATE_COMPLETED:
                 // find order and check, whether cancelling is possible this order
                 $order = new Order($this->request->id);
-                $order->find($this->request->params);
+                $order->find(['order_id' => $found->order_id]);
                 if ($order->allowCancel()) {
                     // cancel and change state to cancelled
                     $found->cancel(1 * $this->request->params['reason']);

--- a/Paycom/Format.php
+++ b/Paycom/Format.php
@@ -94,6 +94,9 @@ class Format
         if ($datetime) {
             return 1000 * strtotime($datetime);
         }
+        if (is_null($datetime)) {
+            return 0;
+        }
 
         return $datetime;
     }


### PR DESCRIPTION
1) Fixed issue with wrong params for find():
Order::find() method was called with wrong params, without order_id, so CancelTransaction method cannot find Order

2) Test.paycom.uz sandbox requires perform_time to be zero, null is not accepted